### PR TITLE
Update dependencies to newest with python3.9 (bullseye)

### DIFF
--- a/flaskup/models.py
+++ b/flaskup/models.py
@@ -3,7 +3,7 @@ import uuid
 import simplejson
 import shutil
 from datetime import date, timedelta
-from werkzeug import secure_filename
+from werkzeug.utils import secure_filename
 from flask import abort, render_template
 from flaskup import app
 from flaskup.utils import send_mail

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-Flask==1.1.1
-Flask-Babel==0.12.2
+Flask==2.0.1
+Flask-Babel==2.0.0
 Flask-Mail==0.9.1
-simplejson==3.16.0
+simplejson==3.17.3
+bcrypt==3.2.0


### PR DESCRIPTION
Following upgrading to bullseye and python 3.9, it was not working anymore.
Updated dependencies and a quick shit of secure_filename.
Added bcrypt in requirements as safer for passwords.